### PR TITLE
Setup unfollowing

### DIFF
--- a/internal/database/feeds.sql.go
+++ b/internal/database/feeds.sql.go
@@ -113,6 +113,25 @@ func (q *Queries) CreateFeedFollow(ctx context.Context, arg CreateFeedFollowPara
 	return i, err
 }
 
+const deleteFeedFollowByUserAndFeedURL = `-- name: DeleteFeedFollowByUserAndFeedURL :execrows
+DELETE FROM feed_follows 
+WHERE feed_follows.user_id = $1 
+AND feed_follows.feed_id = (SELECT id FROM feeds WHERE url = $2)
+`
+
+type DeleteFeedFollowByUserAndFeedURLParams struct {
+	UserID uuid.UUID
+	Url    string
+}
+
+func (q *Queries) DeleteFeedFollowByUserAndFeedURL(ctx context.Context, arg DeleteFeedFollowByUserAndFeedURLParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteFeedFollowByUserAndFeedURL, arg.UserID, arg.Url)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getFeedByURL = `-- name: GetFeedByURL :one
 SELECT id, created_at, updated_at, name, url, user_id FROM feeds WHERE url = $1
 `

--- a/sql/queries/feeds.sql
+++ b/sql/queries/feeds.sql
@@ -58,3 +58,8 @@ JOIN users u ON ff.user_id = u.id
 JOIN feeds f ON ff.feed_id = f.id
 WHERE ff.user_id = $1
 ORDER BY ff.created_at DESC;
+
+-- name: DeleteFeedFollowByUserAndFeedURL :execrows
+DELETE FROM feed_follows 
+WHERE feed_follows.user_id = $1 
+AND feed_follows.feed_id = (SELECT id FROM feeds WHERE url = $2);


### PR DESCRIPTION
This pull request adds support for users to unfollow feeds by URL, including both backend and CLI changes. The main updates involve a new SQL query and Go handler to delete a feed follow record, as well as registering the new `unfollow` command in the CLI.

**Unfollow feed feature:**

* Added the SQL query `DeleteFeedFollowByUserAndFeedURL` to delete a feed follow record by user ID and feed URL in `sql/queries/feeds.sql`.
* Implemented the Go method `DeleteFeedFollowByUserAndFeedURL` in `internal/database/feeds.sql.go` to execute the new SQL query, along with its parameter struct.
* Added the `handlerUnfollow` function in `main.go` to handle the unfollow command, including error handling and user feedback.
* Registered the new `unfollow` command in the CLI by updating the command registration in `main.go`.