### PR TITLE
Set up search

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,24 @@ View posts from all followed feeds with pagination support. Shows 5 posts per pa
 
 Posts are sorted by publication date (newest first) and numbered sequentially across pages. Navigation hints are provided to help you move between pages.
 
+#### Search Posts
+
+**Search posts by fuzzy match (title or description):**
+
+```bash
+gator search <term> [page]
+```
+
+- `gator search rust` - Searches titles and descriptions for "rust" and shows page 1 of results.
+- `gator search "openai" 2` - Shows page 2 of search results for "openai".
+
+ 
+Notes:
+
+- Search is case-insensitive and performs a fuzzy substring match using ILIKE on both title and description.
+- Pagination matches the `browse` command: 5 results per page and navigation hints when more results exist.
+- Use quotes for multi-word search terms, e.g. `gator search "machine learning"`.
+
 ### Examples
 
 #### Basic User Setup

--- a/main.go
+++ b/main.go
@@ -330,7 +330,7 @@ func handlerBrowse(s *state, cmd command, user database.User) error {
 
 	if len(cmd.args) >= 1 {
 		// Try to parse the page argument
-		if parsedPage, err := fmt.Sscanf(cmd.args[0], "%d", &page); err != nil || parsedPage != 1 {
+		if parsedPage, err := fmt.Sscanf(cmd.args[0], "%d", &page); err != nil || parsedPage < 1 {
 			return fmt.Errorf("page must be a number, got: %s", cmd.args[0])
 		}
 		if page < 1 {
@@ -410,7 +410,7 @@ func handlerSearch(s *state, cmd command, user database.User) error {
 	query := cmd.args[0]
 	page := int32(1)
 	if len(cmd.args) >= 2 {
-		if parsedPage, err := fmt.Sscanf(cmd.args[1], "%d", &page); err != nil || parsedPage != 1 {
+		if parsedPage, err := fmt.Sscanf(cmd.args[1], "%d", &page); err != nil || parsedPage < 1 {
 			return fmt.Errorf("page must be a number, got: %s", cmd.args[1])
 		}
 		if page < 1 {

--- a/sql/queries/feeds.sql
+++ b/sql/queries/feeds.sql
@@ -87,3 +87,27 @@ JOIN feed_follows ff ON f.id = ff.feed_id
 WHERE ff.user_id = $1
 ORDER BY p.published_at DESC NULLS LAST, p.created_at DESC
 LIMIT $2 OFFSET $3;
+
+-- name: SearchPostsForUser :many
+-- Search posts for a user by fuzzy match against title or description.
+-- Params: user_id uuid, q text (search term), limit int, offset int
+SELECT
+        p.id,
+        p.created_at,
+        p.updated_at,
+        p.title,
+        p.url,
+        p.description,
+        p.published_at,
+        p.feed_id,
+        f.name as feed_name
+FROM posts p
+JOIN feeds f ON p.feed_id = f.id
+JOIN feed_follows ff ON f.id = ff.feed_id
+WHERE ff.user_id = $1
+    AND (
+        p.title ILIKE ('%' || $2 || '%')
+        OR p.description ILIKE ('%' || $2 || '%')
+    )
+ORDER BY p.published_at DESC NULLS LAST, p.created_at DESC
+LIMIT $3 OFFSET $4;


### PR DESCRIPTION
This pull request adds a fuzzy search feature for posts, allowing users to search through the titles and descriptions of posts from their followed feeds. The search is case-insensitive, supports pagination, and integrates with the command-line interface. The most important changes are grouped below:

**Feature Addition: Fuzzy Search for Posts**

* Added a new SQL query `SearchPostsForUser` in `sql/queries/feeds.sql` to search posts by a case-insensitive substring match on title or description, supporting pagination.
* Implemented the corresponding Go method `SearchPostsForUser` in `internal/database/feeds.sql.go`, including new parameter and result types to handle the search logic and results.

**Command-Line Interface Integration**

* Introduced the `handlerSearch` function in `main.go` to process the `search` command, handle pagination, and display results with navigation hints.
* Registered the new `search` command in the CLI command dispatcher, ensuring only logged-in users can access it.

**Documentation Updates**

* Updated `README.md` to document the new `search` command, usage examples, and details about fuzzy matching and pagination.