### PR TITLE
Add http server

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"gator/internal/database"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// User context key for storing authenticated user
+type contextKey string
+
+const userContextKey contextKey = "user"
+
+// AuthenticatedUser represents a user in the request context
+type AuthenticatedUser struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+// generateAPIKey generates a secure random API key
+func generateAPIKey() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+// requireAuth is middleware that requires API key authentication
+func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Get API key from Authorization header
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			s.respondWithError(w, http.StatusUnauthorized, "API key required")
+			return
+		}
+
+		// Extract API key (expect format: "ApiKey <key>")
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || parts[0] != "ApiKey" {
+			s.respondWithError(w, http.StatusUnauthorized, "Invalid authorization format. Use: ApiKey <your-api-key>")
+			return
+		}
+
+		apiKey := parts[1]
+		if apiKey == "" {
+			s.respondWithError(w, http.StatusUnauthorized, "API key cannot be empty")
+			return
+		}
+
+		// Look up user by API key
+		user, err := s.db.GetUserByAPIKey(context.Background(), sql.NullString{
+			String: apiKey,
+			Valid:  true,
+		})
+		if err != nil {
+			s.respondWithError(w, http.StatusUnauthorized, "Invalid API key")
+			return
+		}
+
+		// Add user to request context
+		authUser := AuthenticatedUser{
+			ID:   user.ID,
+			Name: user.Name,
+		}
+		ctx := context.WithValue(r.Context(), userContextKey, authUser)
+		next(w, r.WithContext(ctx))
+	}
+}
+
+// getUserFromContext extracts the authenticated user from request context
+func getUserFromContext(r *http.Request) (AuthenticatedUser, error) {
+	user, ok := r.Context().Value(userContextKey).(AuthenticatedUser)
+	if !ok {
+		return AuthenticatedUser{}, fmt.Errorf("user not found in context")
+	}
+	return user, nil
+}
+
+// Auth handlers
+type registerRequest struct {
+	Name string `json:"name"`
+}
+
+type registerResponse struct {
+	User   AuthenticatedUser `json:"user"`
+	APIKey string            `json:"api_key"`
+}
+
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	if req.Name == "" {
+		s.respondWithError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+
+	// Generate API key
+	apiKey, err := generateAPIKey()
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to generate API key")
+		return
+	}
+
+	// Create user
+	user, err := s.db.CreateUser(context.Background(), database.CreateUserParams{
+		ID:        uuid.New(),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+		Name:      req.Name,
+		ApiKey:    sql.NullString{String: apiKey, Valid: true},
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusConflict, "User already exists")
+		return
+	}
+
+	response := registerResponse{
+		User: AuthenticatedUser{
+			ID:   user.ID,
+			Name: user.Name,
+		},
+		APIKey: apiKey,
+	}
+
+	s.respondWithJSON(w, http.StatusCreated, response)
+}
+
+type loginRequest struct {
+	Name string `json:"name"`
+}
+
+type loginResponse struct {
+	User   AuthenticatedUser `json:"user"`
+	APIKey string            `json:"api_key"`
+}
+
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	if req.Name == "" {
+		s.respondWithError(w, http.StatusBadRequest, "Name is required")
+		return
+	}
+
+	// Get user by name
+	user, err := s.db.GetUser(context.Background(), req.Name)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "Invalid credentials")
+		return
+	}
+
+	// Generate new API key
+	apiKey, err := generateAPIKey()
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to generate API key")
+		return
+	}
+
+	// Update user's API key
+	err = s.db.UpdateUserAPIKey(context.Background(), database.UpdateUserAPIKeyParams{
+		ID:     user.ID,
+		ApiKey: sql.NullString{String: apiKey, Valid: true},
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to update API key")
+		return
+	}
+
+	response := loginResponse{
+		User: AuthenticatedUser{
+			ID:   user.ID,
+			Name: user.Name,
+		},
+		APIKey: apiKey,
+	}
+
+	s.respondWithJSON(w, http.StatusOK, response)
+}

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"html/template"
+	"net/http"
+)
+
+const apiDocTemplate = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Gator RSS Reader API Documentation</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }
+        h1, h2, h3 { color: #333; }
+        code { background: #f4f4f4; padding: 2px 6px; border-radius: 3px; }
+        pre { background: #f4f4f4; padding: 15px; border-radius: 5px; overflow-x: auto; }
+        .endpoint { margin: 20px 0; padding: 15px; border-left: 4px solid #007cba; background: #f9f9f9; }
+        .method { font-weight: bold; color: #007cba; }
+        .auth { color: #d73527; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>Gator RSS Reader API Documentation</h1>
+    
+    <h2>Authentication</h2>
+    <p>Most endpoints require authentication using an API key. Include your API key in the Authorization header:</p>
+    <pre>Authorization: ApiKey &lt;your-api-key&gt;</pre>
+    
+    <h2>Endpoints</h2>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /health</h3>
+        <p>Health check endpoint</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">POST</span> /api/auth/register</h3>
+        <p>Register a new user</p>
+        <pre>{
+  "name": "username"
+}</pre>
+        <p>Returns user info and API key</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">POST</span> /api/auth/login</h3>
+        <p>Login and get a new API key</p>
+        <pre>{
+  "name": "username"
+}</pre>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /api/users <span class="auth">🔒 Auth Required</span></h3>
+        <p>Get all users</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /api/users/me <span class="auth">🔒 Auth Required</span></h3>
+        <p>Get current user info</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /api/feeds</h3>
+        <p>Get all feeds</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">POST</span> /api/feeds <span class="auth">🔒 Auth Required</span></h3>
+        <p>Create a new feed</p>
+        <pre>{
+  "name": "Feed Name",
+  "url": "https://example.com/feed.xml"
+}</pre>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /api/feed-follows <span class="auth">🔒 Auth Required</span></h3>
+        <p>Get feeds you're following</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">POST</span> /api/feed-follows <span class="auth">🔒 Auth Required</span></h3>
+        <p>Follow a feed</p>
+        <pre>{
+  "feed_url": "https://example.com/feed.xml"
+}</pre>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">DELETE</span> /api/feed-follows <span class="auth">🔒 Auth Required</span></h3>
+        <p>Unfollow a feed</p>
+        <pre>{
+  "feed_url": "https://example.com/feed.xml"
+}</pre>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /api/posts <span class="auth">🔒 Auth Required</span></h3>
+        <p>Get posts from feeds you follow</p>
+        <p>Query parameters: <code>page</code> (default: 1), <code>limit</code> (default: 10, max: 100)</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /api/posts/search <span class="auth">🔒 Auth Required</span></h3>
+        <p>Search posts</p>
+        <p>Query parameters: <code>q</code> (required), <code>page</code> (default: 1), <code>limit</code> (default: 10, max: 100)</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">GET</span> /api/bookmarks <span class="auth">🔒 Auth Required</span></h3>
+        <p>Get your bookmarked posts</p>
+        <p>Query parameters: <code>page</code> (default: 1), <code>limit</code> (default: 10, max: 100)</p>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">POST</span> /api/bookmarks <span class="auth">🔒 Auth Required</span></h3>
+        <p>Bookmark a post</p>
+        <pre>{
+  "post_id": "uuid-of-post"
+}</pre>
+    </div>
+    
+    <div class="endpoint">
+        <h3><span class="method">DELETE</span> /api/bookmarks/{postId} <span class="auth">🔒 Auth Required</span></h3>
+        <p>Remove a bookmark</p>
+    </div>
+    
+    <h2>Example Usage</h2>
+    <pre># Register a new user
+curl -X POST http://localhost:8080/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"name": "alice"}'
+
+# Use the API key from registration response
+export API_KEY="your-api-key-here"
+
+# Create a feed
+curl -X POST http://localhost:8080/api/feeds \
+  -H "Authorization: ApiKey $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Example Blog", "url": "https://example.com/feed.xml"}'
+
+# Get posts
+curl -H "Authorization: ApiKey $API_KEY" \
+  "http://localhost:8080/api/posts?page=1&limit=5"
+
+# Search posts
+curl -H "Authorization: ApiKey $API_KEY" \
+  "http://localhost:8080/api/posts/search?q=golang&page=1&limit=5"</pre>
+</body>
+</html>
+`
+
+func (s *Server) handleDocs(w http.ResponseWriter, r *http.Request) {
+	tmpl, err := template.New("docs").Parse(apiDocTemplate)
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to render documentation")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	tmpl.Execute(w, nil)
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,0 +1,613 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"gator/internal/database"
+	"gator/internal/rss"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// User handlers
+func (s *Server) handleGetUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := s.db.GetUsers(context.Background())
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to get users")
+		return
+	}
+
+	type userResponse struct {
+		ID        uuid.UUID `json:"id"`
+		Name      string    `json:"name"`
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	response := make([]userResponse, len(users))
+	for i, user := range users {
+		response[i] = userResponse{
+			ID:        user.ID,
+			Name:      user.Name,
+			CreatedAt: user.CreatedAt,
+			UpdatedAt: user.UpdatedAt,
+		}
+	}
+
+	s.respondWithJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) handleGetCurrentUser(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	s.respondWithJSON(w, http.StatusOK, user)
+}
+
+// Feed handlers
+func (s *Server) handleGetFeeds(w http.ResponseWriter, r *http.Request) {
+	feeds, err := s.db.GetFeedsWithUsers(context.Background())
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to get feeds")
+		return
+	}
+
+	type feedResponse struct {
+		ID        uuid.UUID `json:"id"`
+		Name      string    `json:"name"`
+		URL       string    `json:"url"`
+		UserName  string    `json:"user_name"`
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	response := make([]feedResponse, len(feeds))
+	for i, feed := range feeds {
+		response[i] = feedResponse{
+			ID:        feed.ID,
+			Name:      feed.Name,
+			URL:       feed.Url,
+			UserName:  feed.UserName,
+			CreatedAt: feed.CreatedAt,
+			UpdatedAt: feed.UpdatedAt,
+		}
+	}
+
+	s.respondWithJSON(w, http.StatusOK, response)
+}
+
+type createFeedRequest struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+func (s *Server) handleCreateFeed(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	var req createFeedRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	if req.Name == "" || req.URL == "" {
+		s.respondWithError(w, http.StatusBadRequest, "Name and URL are required")
+		return
+	}
+
+	// Create feed
+	feed, err := s.db.CreateFeed(context.Background(), database.CreateFeedParams{
+		ID:        uuid.New(),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+		Name:      req.Name,
+		Url:       req.URL,
+		UserID:    user.ID,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusConflict, "Feed already exists")
+		return
+	}
+
+	// Auto-follow the feed
+	_, err = s.db.CreateFeedFollow(context.Background(), database.CreateFeedFollowParams{
+		ID:        uuid.New(),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+		UserID:    user.ID,
+		FeedID:    feed.ID,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to auto-follow feed")
+		return
+	}
+
+	// Fetch and save posts in background
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		client := rss.NewHTTPClient()
+		rssFeed, err := rss.FetchFeed(ctx, client, req.URL)
+		if err == nil {
+			rss.SavePostsToDatabase(ctx, s.db, rssFeed, feed.ID)
+		}
+	}()
+
+	type feedResponse struct {
+		ID        uuid.UUID `json:"id"`
+		Name      string    `json:"name"`
+		URL       string    `json:"url"`
+		UserID    uuid.UUID `json:"user_id"`
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	response := feedResponse{
+		ID:        feed.ID,
+		Name:      feed.Name,
+		URL:       feed.Url,
+		UserID:    feed.UserID,
+		CreatedAt: feed.CreatedAt,
+		UpdatedAt: feed.UpdatedAt,
+	}
+
+	s.respondWithJSON(w, http.StatusCreated, response)
+}
+
+// Feed follow handlers
+func (s *Server) handleGetFeedFollows(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	follows, err := s.db.GetFeedFollowsForUser(context.Background(), user.ID)
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to get feed follows")
+		return
+	}
+
+	type feedFollowResponse struct {
+		ID        uuid.UUID `json:"id"`
+		FeedName  string    `json:"feed_name"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+
+	response := make([]feedFollowResponse, len(follows))
+	for i, follow := range follows {
+		response[i] = feedFollowResponse{
+			ID:        follow.ID,
+			FeedName:  follow.FeedName,
+			CreatedAt: follow.CreatedAt,
+		}
+	}
+
+	s.respondWithJSON(w, http.StatusOK, response)
+}
+
+type createFeedFollowRequest struct {
+	FeedURL string `json:"feed_url"`
+}
+
+func (s *Server) handleCreateFeedFollow(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	var req createFeedFollowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	if req.FeedURL == "" {
+		s.respondWithError(w, http.StatusBadRequest, "Feed URL is required")
+		return
+	}
+
+	// Get feed by URL
+	feed, err := s.db.GetFeedByURL(context.Background(), req.FeedURL)
+	if err != nil {
+		s.respondWithError(w, http.StatusNotFound, "Feed not found")
+		return
+	}
+
+	// Create follow
+	follow, err := s.db.CreateFeedFollow(context.Background(), database.CreateFeedFollowParams{
+		ID:        uuid.New(),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+		UserID:    user.ID,
+		FeedID:    feed.ID,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusConflict, "Already following this feed")
+		return
+	}
+
+	type feedFollowResponse struct {
+		ID        uuid.UUID `json:"id"`
+		FeedName  string    `json:"feed_name"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+
+	response := feedFollowResponse{
+		ID:        follow.ID,
+		FeedName:  follow.FeedName,
+		CreatedAt: follow.CreatedAt,
+	}
+
+	s.respondWithJSON(w, http.StatusCreated, response)
+}
+
+type deleteFeedFollowRequest struct {
+	FeedURL string `json:"feed_url"`
+}
+
+func (s *Server) handleDeleteFeedFollow(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	var req deleteFeedFollowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	if req.FeedURL == "" {
+		s.respondWithError(w, http.StatusBadRequest, "Feed URL is required")
+		return
+	}
+
+	rowsAffected, err := s.db.DeleteFeedFollowByUserAndFeedURL(context.Background(), database.DeleteFeedFollowByUserAndFeedURLParams{
+		UserID: user.ID,
+		Url:    req.FeedURL,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to unfollow feed")
+		return
+	}
+
+	if rowsAffected == 0 {
+		s.respondWithError(w, http.StatusNotFound, "Not following this feed")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Post handlers
+func (s *Server) handleGetPosts(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	// Parse pagination parameters
+	page := int32(1)
+	limit := int32(10)
+
+	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
+		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+			page = int32(p)
+		}
+	}
+
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 && l <= 100 {
+			limit = int32(l)
+		}
+	}
+
+	offset := (page - 1) * limit
+
+	posts, err := s.db.GetPostsForUser(context.Background(), database.GetPostsForUserParams{
+		UserID: user.ID,
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to get posts")
+		return
+	}
+
+	type postResponse struct {
+		ID          uuid.UUID  `json:"id"`
+		Title       string     `json:"title"`
+		URL         string     `json:"url"`
+		Description *string    `json:"description"`
+		PublishedAt *time.Time `json:"published_at"`
+		FeedName    string     `json:"feed_name"`
+		CreatedAt   time.Time  `json:"created_at"`
+	}
+
+	response := make([]postResponse, len(posts))
+	for i, post := range posts {
+		var description *string
+		if post.Description.Valid {
+			description = &post.Description.String
+		}
+
+		var publishedAt *time.Time
+		if post.PublishedAt.Valid {
+			publishedAt = &post.PublishedAt.Time
+		}
+
+		response[i] = postResponse{
+			ID:          post.ID,
+			Title:       post.Title,
+			URL:         post.Url,
+			Description: description,
+			PublishedAt: publishedAt,
+			FeedName:    post.FeedName,
+			CreatedAt:   post.CreatedAt,
+		}
+	}
+
+	s.respondWithJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) handleSearchPosts(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		s.respondWithError(w, http.StatusBadRequest, "Search query 'q' is required")
+		return
+	}
+
+	// Parse pagination parameters
+	page := int32(1)
+	limit := int32(10)
+
+	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
+		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+			page = int32(p)
+		}
+	}
+
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 && l <= 100 {
+			limit = int32(l)
+		}
+	}
+
+	offset := (page - 1) * limit
+
+	posts, err := s.db.SearchPostsForUser(context.Background(), database.SearchPostsForUserParams{
+		UserID:  user.ID,
+		Column2: sql.NullString{String: query, Valid: true},
+		Limit:   limit,
+		Offset:  offset,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to search posts")
+		return
+	}
+
+	type postResponse struct {
+		ID          uuid.UUID  `json:"id"`
+		Title       string     `json:"title"`
+		URL         string     `json:"url"`
+		Description *string    `json:"description"`
+		PublishedAt *time.Time `json:"published_at"`
+		FeedName    string     `json:"feed_name"`
+		CreatedAt   time.Time  `json:"created_at"`
+	}
+
+	response := make([]postResponse, len(posts))
+	for i, post := range posts {
+		var description *string
+		if post.Description.Valid {
+			description = &post.Description.String
+		}
+
+		var publishedAt *time.Time
+		if post.PublishedAt.Valid {
+			publishedAt = &post.PublishedAt.Time
+		}
+
+		response[i] = postResponse{
+			ID:          post.ID,
+			Title:       post.Title,
+			URL:         post.Url,
+			Description: description,
+			PublishedAt: publishedAt,
+			FeedName:    post.FeedName,
+			CreatedAt:   post.CreatedAt,
+		}
+	}
+
+	s.respondWithJSON(w, http.StatusOK, response)
+}
+
+// Bookmark handlers
+func (s *Server) handleGetBookmarks(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	// Parse pagination parameters
+	page := int32(1)
+	limit := int32(10)
+
+	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
+		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+			page = int32(p)
+		}
+	}
+
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 && l <= 100 {
+			limit = int32(l)
+		}
+	}
+
+	offset := (page - 1) * limit
+
+	bookmarks, err := s.db.GetBookmarksForUser(context.Background(), database.GetBookmarksForUserParams{
+		UserID: user.ID,
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to get bookmarks")
+		return
+	}
+
+	type bookmarkResponse struct {
+		PostID       uuid.UUID  `json:"post_id"`
+		Title        string     `json:"title"`
+		URL          string     `json:"url"`
+		Description  *string    `json:"description"`
+		PublishedAt  *time.Time `json:"published_at"`
+		FeedName     string     `json:"feed_name"`
+		BookmarkedAt time.Time  `json:"bookmarked_at"`
+	}
+
+	response := make([]bookmarkResponse, len(bookmarks))
+	for i, bookmark := range bookmarks {
+		var description *string
+		if bookmark.Description.Valid {
+			description = &bookmark.Description.String
+		}
+
+		var publishedAt *time.Time
+		if bookmark.PublishedAt.Valid {
+			publishedAt = &bookmark.PublishedAt.Time
+		}
+
+		response[i] = bookmarkResponse{
+			PostID:       bookmark.ID,
+			Title:        bookmark.Title,
+			URL:          bookmark.Url,
+			Description:  description,
+			PublishedAt:  publishedAt,
+			FeedName:     bookmark.FeedName,
+			BookmarkedAt: bookmark.BookmarkedAt,
+		}
+	}
+
+	s.respondWithJSON(w, http.StatusOK, response)
+}
+
+type createBookmarkRequest struct {
+	PostID string `json:"post_id"`
+}
+
+func (s *Server) handleCreateBookmark(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	var req createBookmarkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid JSON")
+		return
+	}
+
+	postID, err := uuid.Parse(req.PostID)
+	if err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid post ID format")
+		return
+	}
+
+	// Check if post exists
+	_, err = s.db.GetPostByID(context.Background(), postID)
+	if err != nil {
+		s.respondWithError(w, http.StatusNotFound, "Post not found")
+		return
+	}
+
+	// Create bookmark
+	bookmark, err := s.db.CreateBookmark(context.Background(), database.CreateBookmarkParams{
+		ID:        uuid.New(),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+		UserID:    user.ID,
+		PostID:    postID,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to create bookmark")
+		return
+	}
+
+	if bookmark.ID == uuid.Nil {
+		s.respondWithError(w, http.StatusConflict, "Post already bookmarked")
+		return
+	}
+
+	type bookmarkResponse struct {
+		ID        uuid.UUID `json:"id"`
+		PostID    uuid.UUID `json:"post_id"`
+		UserID    uuid.UUID `json:"user_id"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+
+	response := bookmarkResponse{
+		ID:        bookmark.ID,
+		PostID:    bookmark.PostID,
+		UserID:    bookmark.UserID,
+		CreatedAt: bookmark.CreatedAt,
+	}
+
+	s.respondWithJSON(w, http.StatusCreated, response)
+}
+
+func (s *Server) handleDeleteBookmark(w http.ResponseWriter, r *http.Request) {
+	user, err := getUserFromContext(r)
+	if err != nil {
+		s.respondWithError(w, http.StatusUnauthorized, "User not authenticated")
+		return
+	}
+
+	postIDStr := r.PathValue("postId")
+	postID, err := uuid.Parse(postIDStr)
+	if err != nil {
+		s.respondWithError(w, http.StatusBadRequest, "Invalid post ID format")
+		return
+	}
+
+	rowsAffected, err := s.db.DeleteBookmark(context.Background(), database.DeleteBookmarkParams{
+		UserID: user.ID,
+		PostID: postID,
+	})
+	if err != nil {
+		s.respondWithError(w, http.StatusInternalServerError, "Failed to delete bookmark")
+		return
+	}
+
+	if rowsAffected == 0 {
+		s.respondWithError(w, http.StatusNotFound, "Bookmark not found")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"encoding/json"
+	"gator/internal/database"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Server holds the HTTP server and dependencies
+type Server struct {
+	db     *database.Queries
+	router *http.ServeMux
+	port   string
+}
+
+// NewServer creates a new HTTP server instance
+func NewServer(db *database.Queries, port string) *Server {
+	s := &Server{
+		db:     db,
+		router: http.NewServeMux(),
+		port:   port,
+	}
+	s.setupRoutes()
+	return s
+}
+
+// Start starts the HTTP server
+func (s *Server) Start() error {
+	log.Printf("Starting HTTP server on port %s", s.port)
+	return http.ListenAndServe(":"+s.port, s.router)
+}
+
+// setupRoutes configures all the API endpoints
+func (s *Server) setupRoutes() {
+	// Health check and docs
+	s.router.HandleFunc("GET /health", s.handleHealth)
+	s.router.HandleFunc("GET /api/docs", s.handleDocs)
+
+	// Authentication
+	s.router.HandleFunc("POST /api/auth/register", s.handleRegister)
+	s.router.HandleFunc("POST /api/auth/login", s.handleLogin)
+
+	// User endpoints (require authentication)
+	s.router.HandleFunc("GET /api/users", s.requireAuth(s.handleGetUsers))
+	s.router.HandleFunc("GET /api/users/me", s.requireAuth(s.handleGetCurrentUser))
+
+	// Feed endpoints
+	s.router.HandleFunc("GET /api/feeds", s.handleGetFeeds)
+	s.router.HandleFunc("POST /api/feeds", s.requireAuth(s.handleCreateFeed))
+
+	// Feed follow endpoints
+	s.router.HandleFunc("GET /api/feed-follows", s.requireAuth(s.handleGetFeedFollows))
+	s.router.HandleFunc("POST /api/feed-follows", s.requireAuth(s.handleCreateFeedFollow))
+	s.router.HandleFunc("DELETE /api/feed-follows", s.requireAuth(s.handleDeleteFeedFollow))
+
+	// Post endpoints
+	s.router.HandleFunc("GET /api/posts", s.requireAuth(s.handleGetPosts))
+	s.router.HandleFunc("GET /api/posts/search", s.requireAuth(s.handleSearchPosts))
+
+	// Bookmark endpoints
+	s.router.HandleFunc("GET /api/bookmarks", s.requireAuth(s.handleGetBookmarks))
+	s.router.HandleFunc("POST /api/bookmarks", s.requireAuth(s.handleCreateBookmark))
+	s.router.HandleFunc("DELETE /api/bookmarks/{postId}", s.requireAuth(s.handleDeleteBookmark))
+}
+
+// Response helpers
+func (s *Server) respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(payload)
+}
+
+func (s *Server) respondWithError(w http.ResponseWriter, code int, message string) {
+	type errorResponse struct {
+		Error string `json:"error"`
+	}
+	s.respondWithJSON(w, code, errorResponse{Error: message})
+}
+
+// Health check endpoint
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	type healthResponse struct {
+		Status string `json:"status"`
+		Time   string `json:"time"`
+	}
+	s.respondWithJSON(w, http.StatusOK, healthResponse{
+		Status: "ok",
+		Time:   time.Now().UTC().Format(time.RFC3339),
+	})
+}

--- a/internal/database/bookmarks.sql.go
+++ b/internal/database/bookmarks.sql.go
@@ -16,7 +16,6 @@ import (
 const createBookmark = `-- name: CreateBookmark :one
 INSERT INTO bookmarks (id, created_at, updated_at, user_id, post_id)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (user_id, post_id) DO NOTHING
 RETURNING id, created_at, updated_at, user_id, post_id
 `
 

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -52,4 +52,5 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	Name      string
+	ApiKey    sql.NullString
 }

--- a/sql/queries/bookmarks.sql
+++ b/sql/queries/bookmarks.sql
@@ -1,7 +1,6 @@
 -- name: CreateBookmark :one
 INSERT INTO bookmarks (id, created_at, updated_at, user_id, post_id)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (user_id, post_id) DO NOTHING
 RETURNING *;
 
 -- name: DeleteBookmark :execrows

--- a/sql/queries/users.sql
+++ b/sql/queries/users.sql
@@ -1,15 +1,22 @@
 -- name: CreateUser :one
-INSERT INTO users (id, created_at, updated_at, name)
+INSERT INTO users (id, created_at, updated_at, name, api_key)
 VALUES (
     $1,
     $2,
     $3,
-    $4
+    $4,
+    $5
 )
 RETURNING *;
 
 -- name: GetUser :one
 SELECT * FROM users WHERE name = $1;
+
+-- name: GetUserByAPIKey :one
+SELECT * FROM users WHERE api_key = $1;
+
+-- name: UpdateUserAPIKey :exec
+UPDATE users SET api_key = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2;
 
 -- name: GetUsers :many
 SELECT * FROM users;

--- a/sql/schema/006_api_keys.sql
+++ b/sql/schema/006_api_keys.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN api_key TEXT UNIQUE;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN api_key;


### PR DESCRIPTION
This pull request introduces API key-based authentication to the Gator RSS Reader and adds a new HTTP server implementation for a RESTful API. The changes include a new authentication system, user registration and login endpoints, API documentation, and updates to the database schema and queries to support API keys. The CLI is updated to support starting the HTTP server. These changes lay the foundation for secure access to the API and expand the application's capabilities beyond CLI usage.

**Authentication and User Management:**

* Added API key generation and verification logic, as well as user registration and login handlers in `internal/api/auth.go`, enabling secure user authentication via API keys.
* Updated the `User` model and related database queries to include an `api_key` field, supporting storage and retrieval of API keys for users.
**HTTP API Server Implementation:**

* Introduced a new HTTP server in `internal/api/server.go` with route setup for authentication, users, feeds, feed follows, posts, and bookmarks, including health check and documentation endpoints.
* Added a handler in `main.go` to start the HTTP API server via the CLI with the new `serve` command. 

**API Documentation:**

* Added a new HTML documentation endpoint in `internal/api/docs.go` to provide users with clear instructions and examples for using the API.

**Database Schema and Migrations:**

* Added a migration script `sql/schema/006_api_keys.sql` to add the `api_key` column to the `users` table, ensuring uniqueness and supporting API key authentication.

**CLI Compatibility:**

* Updated CLI user creation logic to ensure CLI users do not receive API keys by default, maintaining backwards compatibility.